### PR TITLE
Read characters from zips in CC data folder

### DIFF
--- a/CustomCharacters/Tools/ZipExtensions.cs
+++ b/CustomCharacters/Tools/ZipExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Ionic.Zip;
+
+namespace CustomCharacters
+{
+    internal static class ZipExtensions
+    {
+        public static string[] ReadAllLines(this ZipEntry zipEntry)
+        {
+            if (zipEntry == null)
+                throw new ArgumentNullException(nameof(zipEntry));
+
+            var lines = new List<string>();
+            using (var stream = zipEntry.OpenReader())
+            using (var reader = new StreamReader(stream))
+            {
+                string line = null;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    lines.Add(line);
+                }
+            }
+
+            return lines.ToArray();
+        }
+
+        public static byte[] ReadAllBytes(this ZipEntry zipEntry)
+        {
+            if (zipEntry == null)
+                throw new ArgumentNullException(nameof(zipEntry));
+
+            using (var ms = new MemoryStream())
+            {
+                zipEntry.Extract(ms);
+                ms.Position = 0;
+                return ms.ToArray();
+            }
+        }
+    }
+}


### PR DESCRIPTION
I thought it would be good if the CC mod could load zips. Turns out it wasn't too much work to implement. This should make it easier for people to get characters mods from modworkshop (you can skip the unzip step) and allows for "character packs" since it can load multiple characters from a zip. To do that you just make subfolder, each with their own characterdata.txt and associated files.