### PR TITLE
Use Alexandria's AddUISprite() to prevent conflicts with other UI sprites

### DIFF
--- a/CustomCharacters/CharacterBuilding/SpriteHandler.cs
+++ b/CustomCharacters/CharacterBuilding/SpriteHandler.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 
 using UnityEngine;
 using GungeonAPI;
+using Alexandria.CharacterAPI; // AddUISprite()
 
 namespace CustomCharacters
 {
@@ -230,22 +231,7 @@ namespace CustomCharacters
 
         public static void HandleFacecards(PlayerController player, CustomCharacterData data)
         {
-            var atlas = uiAtlas;
-            var atlasTex = atlas.Texture;
-
-            dfAtlas.ItemInfo info = new dfAtlas.ItemInfo();
-            info.name = player.name + "_facecard";
-            info.region = TextureStitcher.AddFaceCardToAtlas(data.faceCard, atlasTex, uiFaceCards.Count, uiFacecardBounds);
-            info.sizeInPixels = faceCardSizeInPixels;
-
-            atlas.AddItem(info);
-
-            if (atlas.Replacement)
-            {
-                atlas.Replacement.Material.mainTexture = atlasTex;
-            }
-
-            uiFaceCards.Add(info);
+            ToolsCharApi.AddUISprite(data.faceCard, player.name + "_facecard");
         }
 
         public static void HandlePunchoutSprites(PunchoutPlayerController player, CustomCharacterData data)
@@ -276,13 +262,7 @@ namespace CustomCharacters
                 int count = Mathf.Min(data.punchoutFaceCards.Count, 3);
                 for (int i = 0; i < count; i++)
                 {
-                    dfAtlas.ItemInfo info = new dfAtlas.ItemInfo();
-                    info.name = data.nameInternal + "_punchout_facecard" + (i + 1);
-                    info.region = TextureStitcher.AddFaceCardToAtlas(data.punchoutFaceCards[i], atlasTex, uiFaceCards.Count, uiFacecardBounds);
-                    info.sizeInPixels = faceCardSizeInPixels;
-
-                    atlas.AddItem(info);
-                    uiFaceCards.Add(info);
+                    ToolsCharApi.AddUISprite(data.punchoutFaceCards[i], data.nameInternal + "_punchout_facecard" + (i + 1));
                 }
             }
         }

--- a/CustomCharacters/CustomCharacters.csproj
+++ b/CustomCharacters/CustomCharacters.csproj
@@ -47,6 +47,9 @@
     <Reference Include="ModTheGungeonAPI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EtG.ModTheGungeonAPI.1.6.1\lib\net35\ModTheGungeonAPI.dll</HintPath>
     </Reference>
+    <Reference Include="Alexandria, Version=0.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EtG.Alexandria.0.4.14\lib\net35\Alexandria.dll</HintPath>
+    </Reference>
     <Reference Include="Mono.Cecil, Version=0.10.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.10.4\lib\net35\Mono.Cecil.dll</HintPath>
     </Reference>

--- a/CustomCharacters/CustomCharactersModule.cs
+++ b/CustomCharacters/CustomCharactersModule.cs
@@ -14,7 +14,7 @@ namespace CustomCharacters
     [BepInPlugin(GUID, "Custom Characters Mod", version)]
     public class CustomCharactersModule : BaseUnityPlugin
     {
-        public const string version = "2.2.7";
+        public const string version = "2.2.8";
         public const string GUID = "kyle.etg.CCM";
         private static bool hasInitialized;
         public void Start()

--- a/CustomCharacters/packages.config
+++ b/CustomCharacters/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="BepInEx.BaseLib" version="5.4.21" targetFramework="net35" />
   <package id="BepInEx.Core" version="5.4.21" targetFramework="net35" />
+  <package id="EtG.Alexandria" version="0.4.14" targetFramework="net35" />
   <package id="EtG.GameLibs" version="2.1.9.1" targetFramework="net35" />
   <package id="EtG.ModTheGungeonAPI" version="1.6.1" targetFramework="net35" />
   <package id="EtG.UnityEngine" version="1.0.0" targetFramework="net35" />


### PR DESCRIPTION
Short Version: PR fixes major UI sprite conflicts between CCM and Alexandria (and internal CCM sprite conflicts when using lots of modded characters)

---------

Long version:
- CCM was deciding where to put facecards / punchout sprites in the UI atlas by using a [harcoded offset](https://github.com/KyleTheScientist/GungeonCharacters/blob/master/CustomCharacters/CharacterBuilding/SpriteHandler.cs#L26) corresponding to the first row of pixels that went completely unused in the vanilla atlas
- Alexandria's UI sprite setup code has always tried to put sprites in the vanilla UI atlas in the first available spot, but due to buggy code it actually ended up failing to find open spots altogether most of the time
- Alexandria's UI setup code was just updated so it actually correctly finds free space for UI sprites now, and starts populating the vanilla UI atlas from the topleft-most available space
- Fixing the UI bug in Alexandria revealed an issue with CCM's UI sprite setup, which assumes it's working with a vanilla atlas and doesn't bother checking if the area it's putting facecard / punchout sprites is occupied by another sprite
- The end result is that any mod that adds UI sprites and gets loaded before CCM ends up getting its UI sprites completely clobbered by CCM's UI sprite setup

The fix involves adding Alexandria as a dependency to CCM and using Alexandria's UI sprite setup methods so that CCM can coordinate with other mods that add UI sprites to find unused space in the UI atlas. This change also allows CCM to take advantage of Alexandria's ability to resize the UI atlas as needed, which prevents the "Not enough room left on the Facecard Atlas for this facecard!" error from ever happening. :slightly_smiling_face: 

This change will requiring adding Alexandria version 0.4.14 as a dependency to CCM in Thunderstore's `manifest.json`.